### PR TITLE
Old Version of Camera Control has a Bug CVE-2018-1002205

### DIFF
--- a/CameraControl/CameraControl_DevSrc-2013-07-24/CameraControl_Proshots/nikon-camera-control/CameraControlCmd/packages.config
+++ b/CameraControl/CameraControl_DevSrc-2013-07-24/CameraControl_Proshots/nikon-camera-control/CameraControlCmd/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.9.1.8" />
+  <package id="DotNetZip" version="1.11.0" />
   <package id="log4net" version="2.0.0" />
 </packages>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-1002205
high severity
Vulnerable versions: < 1.11.0
Patched version: 1.11.0
DotNetZip.Semvered before 1.11.0 is vulnerable to directory traversal, allowing attackers to write to arbitrary files via a ../ (dot dot slash) in a Zip archive entry that is mishandled during extraction. This vulnerability is also known as 'Zip-Slip'.